### PR TITLE
Widescreen logs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# Default styles:
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = false
+indent_style = tab
+indent_size = 4
+tab_width = 4
+trim_trailing_whitespace = true
+
+[src/content/*]
+indent_style = space
+indent_size = 3
+tab_width = 3

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -82,6 +82,7 @@
   "back": { "message": "Back" },
 
   "log": { "message": "Log" },
+  "request": { "message": "Request" },
   "documentUrl": { "message": "Document URL" },
   "url": { "message": "URL" },
   "method": { "message": "Method" },

--- a/src/content/default.css
+++ b/src/content/default.css
@@ -39,6 +39,9 @@
     --border: #777;
     /* --shadow: #fff8; */
     --dim: #ccc;
+    --log-bg-header: hsl(30, 100%, 46.7%);
+    --log-bg-odd: hsl(30, 100%, 13.3%);
+    --log-bg-even: hsl(30, 100%, 15%);
   }
 }
 

--- a/src/content/options.css
+++ b/src/content/options.css
@@ -635,13 +635,15 @@ section.log {
          }
       }
       tr:nth-of-type(2) {
-         th:nth-of-type(1),
-         th:nth-of-type(7) {
-            border-bottom-left-radius: 2ch;
-         }
-         th:nth-of-type(6),
-         th:nth-of-type(10) {
-            border-bottom-right-radius: 2ch;
+         th {
+            &:nth-of-type(1),
+            &:nth-of-type(7) {
+               border-bottom-left-radius: 2ch;
+            }
+            &:nth-of-type(6),
+            &:nth-of-type(10) {
+               border-bottom-right-radius: 2ch;
+            }
          }
       }
       tr th {

--- a/src/content/options.css
+++ b/src/content/options.css
@@ -5,7 +5,7 @@
 /* ----- General ----- */
 :root {
   --nav-height: 3rem;
-  --maxWidth: 75rem;
+  --maxWidth: calc(100% - 110px); /*Leave enough to show logo on bottom left*/
 }
 
 html {
@@ -47,7 +47,8 @@ article {
 
 section {
   display: none;
-  margin: 0 auto;
+  margin: 0 var(--maxWidth) 0 auto;
+  width: 100%;
   max-width: var(--maxWidth);
   height: calc(100vh - var(--nav-height) - 2rem);
   overflow: auto;
@@ -146,8 +147,9 @@ nav {
   align-items: end;
   color: var(--nav-color);
   height: var(--nav-height);
+  width: 100%;
   max-width: var(--maxWidth);
-  margin: 0 auto;
+  margin: 0 var(--maxWidth) 0 auto;
 }
 
 nav img {
@@ -619,6 +621,77 @@ section.log {
 
 .log td:nth-of-type(7) {
  border-left: 2px solid var(--border);
+}
+
+.log {
+   thead {
+      position: sticky;
+      top: 0;
+      line-height: .5ch;
+      tr:nth-of-type(1) {
+         th {
+            border-top-left-radius: 2ch;
+            border-top-right-radius: 2ch;
+         }
+      }
+      tr:nth-of-type(2) {
+         th:nth-of-type(1),
+         th:nth-of-type(7) {
+            border-bottom-left-radius: 2ch;
+         }
+         th:nth-of-type(6),
+         th:nth-of-type(10) {
+            border-bottom-right-radius: 2ch;
+         }
+      }
+      tr th {
+         background-color: var(--log-bg-header);
+         text-align: center;
+         /* font-weight: bold; */
+      }
+   }
+   tbody tr {
+      &:nth-of-type(odd) {
+         background-color: var(--log-bg-odd);
+      }
+      &:nth-of-type(even) {
+         background-color: var(--log-bg-even);
+      }
+   }
+   th, td {
+      &:nth-of-type(1) {
+         width: 3ch;
+      }
+      &:nth-of-type(2) {
+         width: 7ch;
+      }
+      &:nth-of-type(3) {
+         width: 1em;
+      }
+      &:nth-of-type(4) {
+         width: 7ch;
+      }
+      &:nth-of-type(5) {
+         min-width: calc(75% * (1/4));
+         max-width: 0;
+      }
+      &:nth-of-type(6) {
+         min-width: calc(75% * (3/4));
+         max-width: 0;
+      }
+      &:nth-of-type(7) {
+         min-width: auto;
+      }
+      &:nth-of-type(8) {
+         width: 6ch;
+      }
+      &:nth-of-type(9) {
+         width: auto;
+      }
+      &:nth-of-type(10) {
+         width: 6ch;
+      }
+   }
 }
 
 .log td.incognito::before {

--- a/src/content/options.html
+++ b/src/content/options.html
@@ -583,16 +583,20 @@
       <table>
         <thead>
           <tr>
-            <th style="width: 1.5em;"></th>
-            <th style="width: 5em;" data-i18n="time"></th>
-            <th style="width: 1em;"><img src="../image/container.svg" alt=""></th>
-            <th style="width: 3em;" data-i18n="method"></th>
+            <th colspan="6" data-i18n="request"></th>
+            <th colspan="4" data-i18n="proxy"></th>
+          </tr>
+          <tr>
+            <th></th>
+            <th data-i18n="time"></th>
+            <th><img src="../image/container.svg" alt=""></th>
+            <th data-i18n="method"></th>
             <th data-i18n="documentURL"></th>
             <th data-i18n="url"></th>
-            <th><span data-i18n="proxy"></span>: <span data-i18n="title"></span></th>
-            <th style="width: 3em;" data-i18n="type"></th>
+            <th data-i18n="title"></th>
+            <th data-i18n="type"></th>
             <th data-i18n="hostname"></th>
-            <th style="width: 3em;" data-i18n="port"></th>
+            <th data-i18n="port"></th>
            </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
Adjusted Logs screen to display properly on a widescreen also.
- Changed header into 2 lines to better group the info.
- Added border radius on header for visual.
- Changed header background for visual.
- Added odd/even background changes to differentiate different lines.

---
My widescreen:
![FoxyProxy-extension-Widescreen logs](https://github.com/foxyproxy/browser-extension/assets/1723378/1bb81786-2e80-46a8-93b8-a648a2977f95)

---
Responsive design, vertical:
![FoxyProxy-extension-Widescreen logs2](https://github.com/foxyproxy/browser-extension/assets/1723378/4240edae-f2e1-4de5-a664-3766a73732d1)
