### PR TITLE
Fix wrong usage of non-declared lexical variable

### DIFF
--- a/src/content/proxy.js
+++ b/src/content/proxy.js
@@ -247,14 +247,18 @@ export class Proxy {
 
   // ---------- Quick Add/Exclude Host ---------------------
   static async quickAdd(pref, host) {
-    const activeTab = await this.getActiveTab();
-    const pattern = this.getPattern(activeTab[0].url);
+    const activeTabs = await this.getActiveTab();
+    const activeTabUrlStr = activeTabs[0].url;
+    if (!activeTabUrlStr) { return; }
+    const activeTabUrl = new URL(activeTabUrlStr);
+    if (!activeTabUrl) { return; }
+    const pattern = this.getPattern(activeTabUrlStr);
     if (!pattern) { return; }
 
     const pat = {
       active: true,
       pattern,
-      title: url.hostname,
+      title: activeTabUrl.hostname,
       type: 'regex',
     };
 


### PR DESCRIPTION
See commit's diff for details, thats just a neglect for action `QuickAdd`.