### PR TITLE
Enlarge height of pattern tables

### DIFF
--- a/src/content/options.css
+++ b/src/content/options.css
@@ -461,7 +461,7 @@ details.proxy > summary span:nth-of-type(2):empty::before {
 
 /* ----- Pattern ----- */
 .pattern-box {
-  max-height: 10em;
+  max-height: 100em;
   overflow-y: auto;
   padding: 0 0.5em;
 }


### PR DESCRIPTION
At the moment, the pattern table for each proxy entry is of comparatively small height. This impairs overview of the ruleset.

I suggest to allow to take the tables more height, e.g. ten times.