### PR TITLE
Add loopback and websocket to `options.html`

### DIFF
--- a/src/content/options.html
+++ b/src/content/options.html
@@ -512,13 +512,13 @@
           <select>
             <option value="" disabled selected>&nbsp;</option>
             <option data-type="regex" value="\S+" data-i18n="all"></option>
-            <option data-type="regex" value="^http://.+">HTTP</option>
-            <option data-type="regex" value="^https://.+">HTTPS</option>
-            <option data-type="regex" value="^https?://[^.]+/" data-i18n="plainHost"></option>
-            <option data-type="regex" value="^https?://10(\.\d+){3}/">10.*.*.*</option>
-            <!-- <option data-type="regex" value="^https?://127\.0\.0\.1/">127.0.0.1</option> -->
-            <option data-type="regex" value="^https?://172\.16(\.\d+){2}/">172.16.*.*</option>
-            <option data-type="regex" value="^https?://192\.168(\.\d+){2}/">192.168.*.*</option>
+            <option data-type="regex" value="^(http|ws)://.+">HTTP/WS</option>
+            <option data-type="regex" value="^(http|ws)s://.+">HTTPS/WSS</option>
+            <option data-type="regex" value="^(http|ws)s?://[^.]+/" data-i18n="plainHost"></option>
+            <option data-type="regex" value="^(http|ws)s?://10(\.\d+){3}/">10.*.*.*</option>
+            <option data-type="regex" value="^(http|ws)s?://127(\.\d+){3}/">127.*.*.*</option>
+            <option data-type="regex" value="^(http|ws)s?://172\.16(\.\d+){2}/">172.16.*.*</option>
+            <option data-type="regex" value="^(http|ws)s?://192\.168(\.\d+){2}/">192.168.*.*</option>
           </select>
           <select>
             <option value="include" data-i18n="include"></option>


### PR DESCRIPTION
This PR adds support for ws/wss protocols into the default presets, and also adds a loopback addresses preset.