### PR TITLE
Fix Width popup.html on Russian local

### DIFF
--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -106,5 +106,5 @@
   "help": { "message": "Помощь" },
   "import": { "message": "Импортировать настройки" },
   "options": { "message": "Настройки" },
-  "saveOptions": { "message": "Save" }
+  "saveOptions": { "message": "Сохранить" }
 }

--- a/src/content/popup.css
+++ b/src/content/popup.css
@@ -22,7 +22,7 @@
 body {
   opacity: 0;
   font-size: 12px;
-  width: 25em;
+  width: 30em;
   background-color: var(--bg);
   transition: opacity 0.5s;
 }


### PR DESCRIPTION
Sorry for this, I haven't checked it completely, but with the new localization popup.html the content is not fully displayed.

before:
![firefox_pxNMKUn7HG](https://github.com/user-attachments/assets/c38acd7d-b127-4b61-9861-4f9189eadcd2)

after:
![firefox_keeGDE0yyw](https://github.com/user-attachments/assets/d598343b-cf3a-4959-aebe-34c14a526d55)

p.s: fix "save" local
