### PR TITLE
Allow "Tab proxy" functionality on new and blank tabs

### DIFF
--- a/src/content/on-request.js
+++ b/src/content/on-request.js
@@ -223,8 +223,8 @@ export class OnRequest {
   static setTabProxy(tab, pxy) {
     // const [tab] = await browser.tabs.query({currentWindow: true, active: true});
     switch (true) {
-      case !/https?:\/\/.+/.test(tab.url):                  // unacceptable URLs
-      case this.bypass(tab.url):                            // check local & global passthrough
+      case !/https?:\/\/.+|about:blank|about:newtab/.test(tab.url): // unacceptable URLs
+      case this.bypass(tab.url):                                    // check local & global passthrough
         return;
     }
 

--- a/src/content/popup.js
+++ b/src/content/popup.js
@@ -104,7 +104,7 @@ class Popup {
 
   static async checkTabProxy() {
     const [tab] = await browser.tabs.query({currentWindow: true, active: true});
-    if (!/https?:\/\/.+/.test(tab.url)) { return; }         // unacceptable URLs
+    if (!/https?:\/\/.+|about:blank|about:newtab/.test(tab.url)) { return; } // unacceptable URLs
 
     this.tab = tab;                                         // cache tab
     const item = await browser.runtime.sendMessage({id: 'getTabProxy'});


### PR DESCRIPTION
fixes #157

This change allows to set tab proxy on new and blank tabs. Currently new tabs (which have `about:newtab` URL) and blank tabs (which have `about:blank` URL) are excluded from per-tab proxy functionality.

This makes the following scenarios work:

- Open new tab
- Enter URL of some page that is only available through proxy (i.e. inside internal network or somehow firewalled for other reasons)
- Press Return in URL bar
- Page fails to load
- Press FoxyProxy toolbar button, select proxy, press "Set tab proxy" button
- Try to load page again, page still does not load, proxy is not set

and:

- Click a link (to a page that is available only through proxy) in existing page with middle mouse button or with control key to open it in new tab.
- Page in new tab fails to load (it can be only opened through proxy)
- Press FoxyProxy toolbar button, select proxy, press "Set tab proxy" button
- Try to load page again, page still does not load, proxy is not set

Tested in desktop Firefox 133.0.3. In Chrome, "Tab proxy" is unsupported. I don't have Android devices so I didn't test on Android Firefox.