### PR TITLE
Allow importing settings from HTTP URLs

### DIFF
--- a/src/manifest-basic.json
+++ b/src/manifest-basic.json
@@ -55,6 +55,10 @@
     "privacy"
   ],
 
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self';"
+  },
+
   "commands": {
     "proxyByPatterns": {
       "description": "__MSG_proxyByPatterns__"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -55,6 +55,10 @@
     "privacy"
   ],
 
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self';"
+  },
+
   "commands": {
     "proxyByPatterns": {
       "description": "__MSG_proxyByPatterns__"


### PR DESCRIPTION
Closes #202 


Docs - https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy

Value is taken from Manigest V2 default.