### PR TITLE
Initialize Firefox routing after local preferences load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "browser-extension",
+  "scripts": {
+    "test": "node --test test/*.test.cjs"
+  },
   "devDependencies": {
     "grunt": "1.6.1",
     "grunt-cli": "^1.4.3",

--- a/src/content/background.js
+++ b/src/content/background.js
@@ -2,6 +2,7 @@ import {pref, App} from './app.js';
 import {Sync} from "./sync.js";
 import {Migrate} from './migrate.js';
 import {Proxy} from './proxy.js';
+import {OnRequest} from './on-request.js';
 import './persist.js';
 
 // ---------- process preferences --------------------------
@@ -14,7 +15,16 @@ class ProcessPref {
   static async init() {
     // Chrome: Top-level await is disallowed in service workers
     // user preference
-    await App.getPref();
+    await App.getPref().catch(() => {});
+
+    // Start Firefox request handling from the last local snapshot without
+    // waiting for sync, migration, or proxy-settings housekeeping below.
+    // Older preference formats still need migration, so leave those pending
+    // for the normal Proxy.set() initialization rather than aborting startup.
+    if (App.firefox) {
+      try { OnRequest.init(pref); }
+      catch {}
+    }
 
     // storage sync -> local update
     await Sync.get(pref);

--- a/test/on-request.test.cjs
+++ b/test/on-request.test.cjs
@@ -1,0 +1,114 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function loadOnRequest() {
+  const file = path.join(__dirname, '..', 'src', 'content', 'on-request.js');
+  const source = fs.readFileSync(file, 'utf8')
+    .replace(/^import .*;\n/gm, '')
+    .replace('export class OnRequest', 'class OnRequest') +
+    '\nglobalThis.OnRequest = OnRequest;\n';
+
+  let onRequest;
+  const browser = {
+    action: {
+      setBadgeBackgroundColor() {},
+      setBadgeText() {},
+      setTitle() {},
+    },
+    proxy: {
+      onRequest: {
+        addListener(listener) {
+          onRequest = listener;
+        },
+      },
+    },
+    storage: {
+      session: {
+        get: async () => ({}),
+        set() {},
+      },
+    },
+    tabs: {
+      onCreated: {addListener() {}},
+      onRemoved: {addListener() {}},
+      onUpdated: {addListener() {}},
+    },
+  };
+
+  const context = {
+    App: {allowedTabProxy: () => true},
+    Location: {get: () => ''},
+    Pattern: {
+      get: pattern => pattern,
+      getPassthrough: () => [[], [], []],
+    },
+    RegExp,
+    URL,
+    browser,
+    btoa: value => Buffer.from(value).toString('base64'),
+  };
+
+  vm.runInNewContext(source, context, {filename: file});
+  return {OnRequest: context.OnRequest, onRequest};
+}
+
+function getPref(mode = 'pattern') {
+  return {
+    container: {},
+    data: [{
+      active: true,
+      cc: 'RU',
+      city: '',
+      color: '#fff',
+      exclude: [],
+      hostname: 'proxy.example',
+      include: [{active: true, pattern: 'example\\.ru/', type: 'regex'}],
+      password: '',
+      port: '1080',
+      proxyDNS: true,
+      tabProxy: [],
+      title: 'Russian proxy',
+      type: 'socks5',
+      username: '',
+    }],
+    mode,
+    passthrough: '',
+  };
+}
+
+function getRequest(url = 'https://service.example.ru/auth/sign-in') {
+  return {
+    cookieStoreId: 'firefox-default',
+    incognito: false,
+    tabId: 1,
+    type: 'main_frame',
+    url,
+  };
+}
+
+test('routes a matching request through the configured proxy', () => {
+  const {OnRequest, onRequest} = loadOnRequest();
+  OnRequest.init(getPref());
+  const result = onRequest(getRequest());
+  assert.equal(result.type, 'socks');
+  assert.equal(result.host, 'proxy.example');
+  assert.equal(result.port, 1080);
+  assert.equal(result.proxyDNS, true);
+});
+
+test('routes an unmatched request directly', () => {
+  const {OnRequest, onRequest} = loadOnRequest();
+  OnRequest.init(getPref());
+
+  assert.equal(onRequest(getRequest('https://example.com/')).type, 'direct');
+});
+
+test('routes a request directly when FoxyProxy is disabled', () => {
+  const {OnRequest, onRequest} = loadOnRequest();
+  OnRequest.init(getPref('disable'));
+
+  assert.equal(onRequest(getRequest()).type, 'direct');
+});


### PR DESCRIPTION
## Summary

- initialize Firefox request routing immediately after the local preference snapshot loads
- keep `proxy.onRequest` synchronous; do not hold requests on a Promise
- retain the existing sync, migration, and final `Proxy.set()` initialization afterward
- cover matching, unmatched, and disabled routing behavior with unit tests

## Problem and scope

`OnRequest` starts with `mode = 'disable'` and an empty pattern list. Before this change, the local preferences, sync state, migration, and `browser.proxy.settings.get()` path all ran before `Proxy.set()` eventually called `OnRequest.init()`. A request reaching the already-registered callback during that interval was answered from the temporary defaults and returned `direct`.

This change calls `OnRequest.init(pref)` as soon as `App.getPref()` provides the local snapshot. The later existing initialization still applies any sync/migration changes. An unusable older preference shape is left for that normal migration path.

This does not attempt to process requests made before Firefox loads FoxyProxy or invokes its listener; an extension cannot control those requests. It also does not suspend network requests, so it adds no async request hold or new browser-hang risk.

## Isolated Firefox verification

With Firefox's default background idle timeout and FoxyProxy's existing `persist.js` keepalive intact, I stored pattern preferences, reloaded the temporary add-on, and started a matching request immediately after the extension reload:

- current `main`: in 5/5 trials, the callback ran with `mode='disable'` 3-13 ms before `OnRequest.init()` and the matching request loaded directly;
- this branch: in 5/5 trials, local-snapshot initialization completed before the callback and the request honored the configured unreachable proxy (`proxyConnectFailure`).

No artificial preference delay was used. Unmatched and disabled scenarios continued to load directly.

## Verification

- `npm test` (3/3)
- `git diff --check`
- `web-ext lint --source-dir src --self-hosted` (0 errors, 0 notices; 5 existing compatibility warnings)
- `web-ext build`
- isolated Mozilla Firefox 155 with fresh disposable profiles; the installed Firefox/profile was not used
